### PR TITLE
jQuery Django `CRSF` helper should be `CSRF`.

### DIFF
--- a/djangojs/static/js/djangojs/django.js
+++ b/djangojs/static/js/djangojs/django.js
@@ -172,7 +172,7 @@
         return this.permissions.indexOf(permission) > -1;
     };
 
-    if (window.DJANGO_JS_CRSF) {
+    if (window.DJANGO_JS_CSRF) {
         Django.jquery_csrf();
     }
 

--- a/djangojs/templates/djangojs/django_js_tag.html
+++ b/djangojs/templates/djangojs/django_js_tag.html
@@ -5,7 +5,7 @@
 <script type="text/javascript" src="{% url "js_catalog" %}"></script>
 {% endif %}
 <script>
-    window.DJANGO_JS_CRSF = {% if js.crsf %}true{% else %}false{% endif %};
+    window.DJANGO_JS_CSRF = {% if js.csrf %}true{% else %}false{% endif %};
 </script>
 
 {% if js.jquery %}{% jquery_js %}{% endif %}

--- a/djangojs/templatetags/js.py
+++ b/djangojs/templatetags/js.py
@@ -144,12 +144,12 @@ def jquery_js(version=None, migrate=False):
 
 
 @register.inclusion_tag('djangojs/django_js_tag.html', takes_context=True)
-def django_js(context, jquery=True, i18n=True, crsf=True):
+def django_js(context, jquery=True, i18n=True, csrf=True):
     '''Include Django.js javascript library in the page'''
     return {
         'js': {
             'jquery': _boolean(jquery),
             'i18n': _boolean(i18n),
-            'crsf': _boolean(crsf),
+            'csrf': _boolean(csrf),
         }
     }

--- a/djangojs/tests/test_tags.py
+++ b/djangojs/tests/test_tags.py
@@ -149,14 +149,14 @@ class DjangoJsTagTest(TestCase):
         self.failIf('<script type="text/javascript" src="%s">' % jquery in rendered)
         self.failUnless('<script type="text/javascript" src="%s">' % django_js in rendered)
 
-    def test_django_js_crsf_false(self):
-        '''Should include django.js without jQuery CRSF patch'''
+    def test_django_js_csrf_false(self):
+        '''Should include django.js without jQuery CSRF patch'''
         template = Template('''
             {% load js %}
-            {% django_js crsf="false" %}
+            {% django_js csrf="false" %}
             ''')
         rendered = template.render(Context())
-        self.failUnless('window.DJANGO_JS_CRSF = false;' in rendered)
+        self.failUnless('window.DJANGO_JS_CSRF = false;' in rendered)
 
     def test_django_js_i18n(self):
         '''Should include django.js with i18n support'''

--- a/doc/templatetags.rst
+++ b/doc/templatetags.rst
@@ -52,7 +52,7 @@ It supports the following keyword parameters (in this order if you want to omit 
 =========== ========= ======================================
 ``jquery``  ``true``  Load the jQuery library
 ``i18n``    ``true``  Load the javascript i18n catalog
-``crsf``    ``true``  Patch jQuery.ajax() fot Django CRSF
+``csrf``    ``true``  Patch jQuery.ajax() fot Django CSRF
 =========== ========= ======================================
 
 
@@ -60,7 +60,7 @@ You can disable all this features by simply providing arguments to the template 
 
 .. code-block:: html+django
 
-    {% django_js jquery=false i18n=false crsf=false %}
+    {% django_js jquery=false i18n=false csrf=false %}
 
 
 Internationalization
@@ -86,13 +86,13 @@ jQuery Ajax CSRF
 
 When the ``django_js`` template tag is ininitialized it automatically patch ``jQuery.ajax()`` to handle CSRF tokens on ajax request.
 
-You can disable this feature by setting the ``crsf`` keyword parameter to ``false``.
+You can disable this feature by setting the ``csrf`` keyword parameter to ``false``.
 
 You can manually enable it later with:
 
 .. code-block:: javascript
 
-    Django.jquery_crsf();
+    Django.jquery_csrf();
 
 
 verbatim


### PR DESCRIPTION
See the [docs](https://docs.djangoproject.com/en/dev/ref/contrib/csrf/).
It stands for Cross-Site Request Forgery.

**Breaks backwards compatibility!**

It's possible to keep both versions and write tests for each, but you were already using `csrf/CSRF` in some places and `crsf/CRSF` in others, so I made it all consistent.
