### PR TITLE
Add CSRF helpers to Django.js

### DIFF
--- a/djangojs/static/js/djangojs/django.js
+++ b/djangojs/static/js/djangojs/django.js
@@ -105,27 +105,52 @@
         },
 
         /**
-         *  Fix ajax request with CSRF Django middleware.
+         * Return cookie value by name.
          *  cf. https://docs.djangoproject.com/en/dev/ref/contrib/csrf/#ajax
          */
-        jquery_csrf: function() {
-            $(document).ajaxSend(function(event, xhr, settings) {
-                function getCookie(name) {
-                    var cookieValue = null;
-                    if (document.cookie && document.cookie !== '') {
-                        var cookies = document.cookie.split(';');
-                        for (var i = 0; i < cookies.length; i++) {
-                            var cookie = $.trim(cookies[i]);
-                            // Does this cookie string begin with the name we want?
-                            if (cookie.substring(0, name.length + 1) == (name + '=')) {
-                                cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
-                                break;
-                            }
-                        }
+        _getCookie: function(name) {
+            var cookieValue = null;
+            if (document.cookie && document.cookie !== '') {
+                var cookies = document.cookie.split(';');
+                for (var i = 0; i < cookies.length; i++) {
+                    var cookie = $.trim(cookies[i]);
+                    // Does this cookie string begin with the name we want?
+                    if (cookie.substring(0, name.length + 1) == (name + '=')) {
+                        cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
+                        break;
                     }
-                    return cookieValue;
                 }
+            }
+            return cookieValue;
+        },
 
+        /**
+         * Get the CSRF token from the cookie.
+         */
+        csrf_token: function() {
+            return this._getCookie('csrftoken');
+        },
+
+        /**
+         * Equivalent to ``{% csrf_token %}`` template tag.
+         */
+        csrf_element: function() {
+            var token = this.csrf_token(),
+                elem = [
+                '<input type="hidden" name="csrfmiddlewaretoken" value="',
+                token ? token : '',
+                '">'
+            ];
+
+            return elem.join('');
+        },
+
+        /**
+         *  Fix ajax request with CSRF Django middleware.
+         */
+        jquery_csrf: function() {
+            var getCookie = this._getCookie;
+            $(document).ajaxSend(function(event, xhr, settings) {
                 function sameOrigin(url) {
                     // url could be relative or scheme relative or absolute
                     var host = document.location.host; // host + port

--- a/djangojs/static/js/test/django.specs.js
+++ b/djangojs/static/js/test/django.specs.js
@@ -278,6 +278,23 @@ describe("Django.js", function(){
     });
 
 
+    describe('The CSRF Token', function(){
+        beforeEach(function(){
+            this.csrfToken = $('#csrf-token').text();
+        });
+
+        it("is accessible through csrf_token()", function(){
+            var c = Django.csrf_token();
+            expect(c).toBe(this.csrfToken);
+        });
+
+        it("Template Tag can be replicated with csrf_element()", function(){
+            var $csrfTag = $('#test-csrf-elem input[name="csrfmiddlewaretoken"]');
+            var e = Django.csrf_element();
+            expect(e).toBe($csrfTag[0].outerHTML);
+        });
+    });
+
     describe('jQuery Ajax CSRF Helper', function(){
 
         it("allow to post Django forms with jQuery Ajax", function(){

--- a/djangojs/templates/djangojs/test/djangojs-test-runner.html
+++ b/djangojs/templates/djangojs/test/djangojs-test-runner.html
@@ -9,7 +9,11 @@
 
 {% block body_content %}
   <form id="test-form" action="{% url "test_form" %}" method="POST" style="display: none;">
-    {{csrf_token}}
+    <span id="csrf-token">{{csrf_token}}</span>
+    {{form}}
+  </form>
+  <form id="test-csrf-elem" action="{% url "test_form" %}" method="POST" style="display: none;">
+    {% csrf_token %}
     {{form}}
   </form>
 {% endblock %}

--- a/doc/djangojs.rst
+++ b/doc/djangojs.rst
@@ -99,3 +99,21 @@ Django.js allows you to check basic user attributes and permissions from client 
     if (Django.user.has_perm('myapp.do_something')) {
         do_something();
     }
+
+
+CSRF Tokens
+-----------
+
+Django.js provides some helpers for CSRF protection.
+
+- return the value of the CSRF token
+
+.. code-block:: javascript
+
+    Django.csrf_token();
+
+- return the hidden input element containing the CSRF token, like the ``{% csrf_token %}`` template tag
+
+.. code-block:: javascript
+
+    Django.csrf_element();


### PR DESCRIPTION
`Django.csrf_token();` returns the value of the CSRF token.

`Django.csrf_element();` returns an element containing the CSRF token,
as if you were to use `{% csrf_token %}`.

The primary purpose of this is for creating non-AJAX forms with Javascript rather than Django Forms.
