### PR TITLE
Support Python3 using 2to3.

### DIFF
--- a/djangojs/runners.py
+++ b/djangojs/runners.py
@@ -110,7 +110,7 @@ class PhantomJsRunner(object):
         '''
         separator = '=' * LINE_SIZE
         title = kwargs['title'] if 'title' in kwargs else 'phantomjs output'
-        nb_spaces = (LINE_SIZE - len(title)) / 2
+        nb_spaces = (LINE_SIZE - len(title)) // 2
 
         if VERBOSE:
             print ''

--- a/djangojs/tests/test_context.py
+++ b/djangojs/tests/test_context.py
@@ -175,4 +175,4 @@ class ContextJsonViewTest(TestCase):
         self.assertIsNotNone(response)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response['Content-Type'], 'application/json')
-        self.assertIsNotNone(json.loads(response.content))
+        self.assertIsNotNone(json.loads(response.content.decode()))

--- a/djangojs/tests/test_urls.py
+++ b/djangojs/tests/test_urls.py
@@ -158,7 +158,7 @@ class UrlsJsonViewTest(UrlsTestMixin, TestCase):
 
     def get_result(self):
         self.response = self.client.get(reverse('django_js_urls'))
-        return json.loads(self.response.content)
+        return json.loads(self.response.content.decode())
 
     def test_render(self):
         '''It should render a JSON URLs descriptor'''

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
     include_package_data=True,
     install_requires=['django'],
     license='LGPL',
+    use_2to3 = True,
     classifiers=[
         "Framework :: Django",
         "Development Status :: 4 - Beta",


### PR DESCRIPTION
Have setup run 2to3 during installation.
Use .decode() to get unicode strings in tests.
Use integer division.

All of the tests run correctly and I'm using it in my Django 1.5/Python 3
project. 
