### PR TITLE
Re-introduce Python2.6 support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: python
 python:
+  - 2.6
   - 2.7
   - 3.2
   - 3.3

--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ This is currently a work in progress (API wil not be stable before 1.0) so don't
 Compatibility
 =============
 
-Django.js requires Python 2.7+ and Django 1.4.2+.
+Django.js requires Python 2.6+ and Django 1.4.2+.
 
 
 Installation

--- a/djangojs/runners.py
+++ b/djangojs/runners.py
@@ -22,7 +22,7 @@ from django.utils.encoding import python_2_unicode_compatible
 from djangojs.tap import TapParser
 from djangojs.utils import StorageGlobber
 
-from unittest import TestCase
+from django.utils.unittest import TestCase
 
 #: Console output line length for separators
 LINE_SIZE = 70

--- a/djangojs/tests/test_context.py
+++ b/djangojs/tests/test_context.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
-import unittest
+from django.utils import unittest
 import json
 
 from django.conf import global_settings

--- a/djangojs/tests/test_tags.py
+++ b/djangojs/tests/test_tags.py
@@ -1,4 +1,4 @@
-import unittest
+from django.utils import unittest
 
 from django.contrib.staticfiles.templatetags.staticfiles import static
 from django.core.urlresolvers import reverse

--- a/djangojs/tests/test_tap.py
+++ b/djangojs/tests/test_tap.py
@@ -1,4 +1,4 @@
-import unittest
+from django.utils import unittest
 
 from djangojs.tap import TapParser, TapTest, TapModule, TapAssertion
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -20,7 +20,7 @@ Django.js is inspired from:
 Compatibility
 =============
 
-Django.js requires Python 2.7+ and Django 1.4.2+.
+Django.js requires Python 2.6+ and Django 1.4.2+.
 
 
 Installation


### PR DESCRIPTION
Django.js already supported Python2.6, with the exception of the test suite.  Django bundles unittest2 as `django.utils.unittest`, so the no changes to the tests were needed.

RHEL/CentOS 6 only include Python2.6 by default, which is sadly still a common deployment target. :(
