### PR TITLE
add possibility to exclude/whitelist views belonging to specified module...

### DIFF
--- a/djangojs/conf.py
+++ b/djangojs/conf.py
@@ -19,6 +19,8 @@ DEFAULTS = {
     'JS_URLS_EXCLUDE': None,
     'JS_URLS_NAMESPACES': None,
     'JS_URLS_NAMESPACES_EXCLUDE': None,
+    'JS_URLS_APPS': None,
+    'JS_URLS_APPS_EXCLUDE': None,
     'JS_URLS_UNNAMED': False,
     'JS_CONTEXT': None,
     'JS_CONTEXT_EXCLUDE': None,

--- a/djangojs/urls_serializer.py
+++ b/djangojs/urls_serializer.py
@@ -54,8 +54,21 @@ def _get_urls_for_pattern(pattern, prefix='', namespace=None):
     urls = {}
 
     if issubclass(pattern.__class__, RegexURLPattern):
+        mod_name, obj_name = pattern.callback.__module__, pattern.callback.__name__
+        # check for apps first
+        if settings.JS_URLS_APPS and mod_name:
+            mod_name_present = False
+            for app in settings.JS_URLS_APPS:
+                if mod_name[:len(app)] == app:
+                    mod_name_present = True
+                    break
+            if not mod_name_present:
+                return urls
+        if settings.JS_URLS_APPS_EXCLUDE and mod_name:
+            for app in settings.JS_URLS_APPS_EXCLUDE:
+                if mod_name[:len(app)] == app:
+                    return urls
         if settings.JS_URLS_UNNAMED:
-            mod_name, obj_name = pattern.callback.__module__, pattern.callback.__name__
             try:
                 module = __import__(mod_name, fromlist=[obj_name])
                 obj = getattr(module, obj_name)

--- a/doc/settings.rst
+++ b/doc/settings.rst
@@ -74,6 +74,23 @@ Serialized namespaces blacklist.
 If this setting is specified, URLs from namespaces listed in will not be serialized.
 
 
+``JS_URLS_APPS``
+----------------------
+
+**Default:** ``None``
+
+Serialized applications whitelist. If this setting is specified, only URLs with views belonging to modules listed in will be serialized.
+
+
+``JS_URLS_APPS_EXCLUDE``
+------------------------------
+
+**Default:** ``None``
+
+Serialized applications blacklist.
+If this setting is specified, URLs with views belonging to modules listed in will not be serialized.
+
+
 ``JS_URLS_UNNAMED``
 -------------------
 
@@ -205,6 +222,10 @@ You could have, in your ``settings.py``:
     # Only include admin namespace
     JS_URLS_NAMESPACES = (
         'admin',
+    )
+    # Exclude views belonging to django.contrib.admindocs application
+    JS_URLS_APPS_EXCLUDE = (
+        'django.contrib.admindocs',
     )
     # Only include my apps' translations
     JS_I18N_APPS = ('myapp', 'myapp.other')


### PR DESCRIPTION
add possibility to exclude/whitelist views belonging to specified modules in javascript URL resolver.

the following settings are available for this feature:
## `JS_URLS_APPS`

**Default:** `None`

Serialized applications whitelist. If this setting is specified, only URLs with views belonging to modules listed in will be serialized.
## `JS_URLS_APPS_EXCLUDE`

**Default:** `None`

Serialized applications blacklist.
If this setting is specified, URLs with views belonging to modules listed in will not be serialized.
