### PR TITLE
bower package

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,41 @@
+{
+  "name": "django.js",
+  "description": "Django.js provides tools for JavaScript development with Django.",
+  "homepage": "https://github.com/noirbizarre/django.js/",
+  "author": {
+    "name": "Axel Haustant",
+    "url": "http://noirbizarre.info/"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/noirbizarre/django.js.git"
+  },
+  "licenses": [
+    {
+      "type": "LGPL 3",
+      "url": "http://www.gnu.org/licenses/lgpl-3.0.txt"
+    }
+  ],
+  "version": "0.8.1.dev",
+  "main": [
+    "djangojs/static/js/djangojs/django.js"
+  ],
+  "dependencies": {
+    "jquery": ">=1.8"
+  },
+  "ignore": [
+    "**/.*",
+    "**/*.py",
+    "**/*.sh",
+    "**/*.rc",
+    "**/*.pip",
+    "**/*.po",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests",
+    "requirements",
+    "templates",
+    "tox.ini"
+  ]
+}


### PR DESCRIPTION
add a possibility to install django.js via [bower](https://github.com/bower/bower) (as a static asset).

in addition, if you accept this feature, you'd have to register it like this:

``` bash
bower register django.js https://github.com/noirbizarre/django.js.git
```

and update version in `bower.json` file from time to time.
