### PR TITLE
Fixed minor typo in tags documentation

### DIFF
--- a/doc/templatetags.rst
+++ b/doc/templatetags.rst
@@ -55,7 +55,7 @@ It supports the following keyword parameters (in this order if you want to omit 
 =========== ========= ======================================
 ``jquery``  ``true``  Load the jQuery library
 ``i18n``    ``true``  Load the javascript i18n catalog
-``csrf``    ``true``  Patch jQuery.ajax() fot Django CSRF
+``csrf``    ``true``  Patch jQuery.ajax() for Django CSRF
 ``init``    ``true``  Initialize Django.js on load
 =========== ========= ======================================
 


### PR DESCRIPTION
A minor thing, but github makes editing easy.
