### PR TITLE
Take FORCE_SCRIPT_NAME setting into account

### DIFF
--- a/djangojs/tests/test_urls.py
+++ b/djangojs/tests/test_urls.py
@@ -173,11 +173,12 @@ class UrlsTestMixin(object):
         self.result = self.get_result()  # To take override_settings in account
         self.assertEqual(len(self.result.keys()), 0)
 
-    @override_settings(SCRIPT_NAME="/force_script")
     def test_force_script_name(self):
+        from django.core.urlresolvers import set_script_prefix, clear_script_prefix
+        set_script_prefix("/force_script")
         self.result = self.get_result()  # To take override_settings in account
-        import ipdb; ipdb.set_trace()
         self.assertEqual(self.result['django_js_urls'], '/force_script/djangojs/urls')
+        clear_script_prefix()
 
 
 class UrlsAsDictTest(UrlsTestMixin, TestCase):

--- a/djangojs/tests/test_urls.py
+++ b/djangojs/tests/test_urls.py
@@ -176,11 +176,14 @@ class UrlsTestMixin(object):
     @override_settings(JS_CACHE_DURATION=0)
     def test_force_script_name(self):
         from django.core.urlresolvers import set_script_prefix, clear_script_prefix
-        set_script_prefix("/force_script")
-        self.result = self.get_result()  # To take override_settings in account
-        self.assertEqual(self.result['django_js_urls'], '/force_script/djangojs/urls')
-        clear_script_prefix()
 
+        try:
+            set_script_prefix("/force_script")
+            self.result = self.get_result()  # To take override_settings in account
+        finally:
+            clear_script_prefix()
+
+        self.assertEqual(self.result['django_js_urls'], '/force_script/djangojs/urls')
 
 class UrlsAsDictTest(UrlsTestMixin, TestCase):
 
@@ -216,7 +219,8 @@ class UrlsJsonViewTest(UrlsTestMixin, TestCase):
             url = reverse('django_js_urls')
             set_script_prefix("/force_script")
             response = self.client.get(url)
-            result = json.loads(response.content.decode())
-            self.assertEqual(result['django_js_urls'], '/force_script/djangojs/urls')
         finally:
             clear_script_prefix()
+
+        result = json.loads(response.content.decode())
+        self.assertEqual(result['django_js_urls'], '/force_script/djangojs/urls')

--- a/djangojs/tests/test_urls.py
+++ b/djangojs/tests/test_urls.py
@@ -175,13 +175,13 @@ class UrlsTestMixin(object):
 
     @override_settings(JS_CACHE_DURATION=0)
     def test_force_script_name(self):
-        from django.core.urlresolvers import set_script_prefix, clear_script_prefix
+        from django.core.urlresolvers import set_script_prefix, _prefixes
 
         try:
             set_script_prefix("/force_script")
             self.result = self.get_result()  # To take override_settings in account
         finally:
-            clear_script_prefix()
+            del _prefixes.value
 
         self.assertEqual(self.result['django_js_urls'], '/force_script/djangojs/urls')
 
@@ -214,13 +214,13 @@ class UrlsJsonViewTest(UrlsTestMixin, TestCase):
 
     @override_settings(JS_CACHE_DURATION=0)
     def test_force_script_name(self):
-        from django.core.urlresolvers import set_script_prefix, clear_script_prefix
+        from django.core.urlresolvers import set_script_prefix, _prefixes
         try:
             url = reverse('django_js_urls')
             set_script_prefix("/force_script")
             response = self.client.get(url)
         finally:
-            clear_script_prefix()
+            del _prefixes.value
 
         result = json.loads(response.content.decode())
         self.assertEqual(result['django_js_urls'], '/force_script/djangojs/urls')

--- a/djangojs/tests/test_urls.py
+++ b/djangojs/tests/test_urls.py
@@ -173,6 +173,12 @@ class UrlsTestMixin(object):
         self.result = self.get_result()  # To take override_settings in account
         self.assertEqual(len(self.result.keys()), 0)
 
+    @override_settings(SCRIPT_NAME="/force_script")
+    def test_force_script_name(self):
+        self.result = self.get_result()  # To take override_settings in account
+        import ipdb; ipdb.set_trace()
+        self.assertEqual(self.result['django_js_urls'], '/force_script/djangojs/urls')
+
 
 class UrlsAsDictTest(UrlsTestMixin, TestCase):
 

--- a/djangojs/tests/test_urls.py
+++ b/djangojs/tests/test_urls.py
@@ -173,6 +173,7 @@ class UrlsTestMixin(object):
         self.result = self.get_result()  # To take override_settings in account
         self.assertEqual(len(self.result.keys()), 0)
 
+    @override_settings(JS_CACHE_DURATION=0)
     def test_force_script_name(self):
         from django.core.urlresolvers import set_script_prefix, clear_script_prefix
         set_script_prefix("/force_script")
@@ -207,3 +208,15 @@ class UrlsJsonViewTest(UrlsTestMixin, TestCase):
         self.assertEqual(self.response.status_code, 200)
         self.assertEqual(self.response['Content-Type'], 'application/json')
         self.assertIsNotNone(self.result)
+
+    @override_settings(JS_CACHE_DURATION=0)
+    def test_force_script_name(self):
+        from django.core.urlresolvers import set_script_prefix, clear_script_prefix
+        try:
+            url = reverse('django_js_urls')
+            set_script_prefix("/force_script")
+            response = self.client.get(url)
+            result = json.loads(response.content.decode())
+            self.assertEqual(result['django_js_urls'], '/force_script/djangojs/urls')
+        finally:
+            clear_script_prefix()

--- a/djangojs/urls_serializer.py
+++ b/djangojs/urls_serializer.py
@@ -8,7 +8,7 @@ import sys
 import types
 
 from django.core.serializers.json import DjangoJSONEncoder
-from django.core.urlresolvers import RegexURLPattern, RegexURLResolver
+from django.core.urlresolvers import RegexURLPattern, RegexURLResolver, get_script_prefix
 from django.utils import six
 
 from djangojs.conf import settings
@@ -52,6 +52,9 @@ def urls_as_json():
 
 def _get_urls_for_pattern(pattern, prefix='', namespace=None):
     urls = {}
+
+    if prefix is '':
+        prefix = get_script_prefix()
 
     if issubclass(pattern.__class__, RegexURLPattern):
         if settings.JS_URLS_UNNAMED:
@@ -99,7 +102,7 @@ def _get_urls_for_pattern(pattern, prefix='', namespace=None):
                     full_url = full_url.replace(el, "<>")  # replace by a empty parameter name
             # Unescape charaters
             full_url = RE_ESCAPE.sub(r'\1', full_url)
-            urls[pattern_name] = "/" + full_url
+            urls[pattern_name] = full_url
     elif (CMS_APP_RESOLVER) and (issubclass(pattern.__class__, AppRegexURLResolver)):  # hack for django-cms
         for p in pattern.url_patterns:
             urls.update(_get_urls_for_pattern(p, prefix=prefix, namespace=namespace))


### PR DESCRIPTION
I routinely deploy Django apps behind a reverse proxy where the root url of the Django app is not "/" e.g.
Public facing server will take requests to http://mysite.com/myapp/ and reverse proxy them to http://localhost:8080/

Django.js does not currently handle this situation ([issue #34](https://github.com/noirbizarre/django.js/issues/34) appears to be related) without having to resort to manually prefix urls with your script name in your js files. For example if my app is hosted at http://mysite.com/myapp/ then `Django.url('home')` will give `"/"` rather than the desired `"/myapp/"`.  This pull request should resolve that.
