### PR TITLE
Fix StorageGlobber test suite errors on  Windows

### DIFF
--- a/djangojs/tests/test_globber.py
+++ b/djangojs/tests/test_globber.py
@@ -2,6 +2,7 @@ from django.test import TestCase
 
 from djangojs.utils import StorageGlobber
 
+from os.path import normpath
 
 class StorageGlobberTest(TestCase):
 
@@ -13,7 +14,7 @@ class StorageGlobberTest(TestCase):
     def test_single_js_file(self):
         '''Should handle a single js file name as string'''
         files = 'js/test/libs/jasmine-djangojs.js'
-        expected = ['js/test/libs/jasmine-djangojs.js']
+        expected = [normpath('js/test/libs/jasmine-djangojs.js')]
         self.assertEqual(StorageGlobber.glob(files), expected)
 
     def test_multi_js_file(self):
@@ -21,30 +22,30 @@ class StorageGlobberTest(TestCase):
         files = ['js/test/libs/jasmine-djangojs.js', 'js/test/libs/jasmine.js']
         result = StorageGlobber.glob(files)
 
-        self.assertIn('js/test/libs/jasmine-djangojs.js', result)
-        self.assertIn('js/test/libs/jasmine.js', result)
+        self.assertIn(normpath('js/test/libs/jasmine-djangojs.js'), result)
+        self.assertIn(normpath('js/test/libs/jasmine.js'), result)
 
     def test_single_glob_expression(self):
         '''Should handle a single glob pattern as js file list'''
         files = 'js/test/libs/jasmine-*.js'
         result = StorageGlobber.glob(files)
 
-        self.assertIn('js/test/libs/jasmine-djangojs.js', result)
-        self.assertIn('js/test/libs/jasmine-html.js', result)
-        self.assertIn('js/test/libs/jasmine-jquery.js', result)
-        self.assertNotIn('js/test/libs/jasmine.js', result)
+        self.assertIn(normpath('js/test/libs/jasmine-djangojs.js'), result)
+        self.assertIn(normpath('js/test/libs/jasmine-html.js'), result)
+        self.assertIn(normpath('js/test/libs/jasmine-jquery.js'), result)
+        self.assertNotIn(normpath('js/test/libs/jasmine.js'), result)
 
     def test_multi_glob_expression(self):
         '''Should handle a glob pattern list as js file list'''
         files = ['js/test/libs/jasmine-*.js', 'js/test/libs/qunit-*.js']
         result = StorageGlobber.glob(files)
 
-        self.assertIn('js/test/libs/jasmine-djangojs.js', result)
-        self.assertIn('js/test/libs/jasmine-html.js', result)
-        self.assertIn('js/test/libs/jasmine-jquery.js', result)
-        self.assertIn('js/test/libs/qunit-tap.js', result)
-        self.assertNotIn('js/test/libs/jasmine.js', result)
-        self.assertNotIn('js/test/libs/qunit.js', result)
+        self.assertIn(normpath('js/test/libs/jasmine-djangojs.js'), result)
+        self.assertIn(normpath('js/test/libs/jasmine-html.js'), result)
+        self.assertIn(normpath('js/test/libs/jasmine-jquery.js'), result)
+        self.assertIn(normpath('js/test/libs/qunit-tap.js'), result)
+        self.assertNotIn(normpath('js/test/libs/jasmine.js'), result)
+        self.assertNotIn(normpath('js/test/libs/qunit.js'), result)
 
     def test_preserve_order(self):
         '''Should preserve declaration order'''
@@ -52,9 +53,9 @@ class StorageGlobberTest(TestCase):
         files = ['js/test/libs/jasmine.js', 'js/djangojs/django.js', 'js/test/libs/qunit-*.js']
         result = StorageGlobber.glob(files)
 
-        self.assertEqual(result[0], 'js/test/libs/jasmine.js')
-        self.assertEqual(result[1], 'js/djangojs/django.js')
+        self.assertEqual(result[0], normpath('js/test/libs/jasmine.js'))
+        self.assertEqual(result[1], normpath('js/djangojs/django.js'))
 
         for lib in result[2:]:
-            self.assertIn('js/test/libs/qunit-', lib)
+            self.assertIn(normpath('js/test/libs/qunit-'), lib)
             self.assertTrue(lib.endswith('.js'))

--- a/djangojs/utils.py
+++ b/djangojs/utils.py
@@ -57,10 +57,12 @@ class StorageGlobber(object):
         '''
         files = files or []
         if isinstance(files, str):
+            files = os.path.normpath(files)
             matches = lambda path: matches_patterns(path, [files])
             return [path for path in cls.get_static_files() if matches(path)]
         elif isinstance(files, (list, tuple)):
             all_files = cls.get_static_files()
+            files = [os.path.normpath(f) for f in files]
             sorted_result = []
             for pattern in files:
                 sorted_result.extend([f for f in all_files if matches_patterns(f, [pattern])])
@@ -78,5 +80,5 @@ class StorageGlobber(object):
                     prefixed_path = path
 
                 if prefixed_path not in files:
-                    files.append(prefixed_path)
+                    files.append(os.path.normpath(prefixed_path))
         return files


### PR DESCRIPTION
The StorageGlobber tests were failing on windows
because the paths get normalized to use two slashed by os.path.join.
Fixed by normalizing all paths in StorageGlobber and changing
expected results in the tests to use the normalized form.
