### PR TITLE
Coping with UTF8 encoding for CHANGELOG.rst

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ def rst(filename):
      - code-block directive
      - travis ci build badge
     '''
-    content = open(filename).read()
+    content = open(filename, encoding="utf-8").read()
     for regex, replacement in PYPI_RST_FILTERS:
         content = re.sub(regex, replacement, content)
     return content


### PR DESCRIPTION
This is a fix for issue 37 that I had and pip now deploys it automatically without error.  I am currently deploying from my github
