### PR TITLE
Added a missing comma in .travis.yml and excluded the development versio...

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,12 @@ python:
 env:
     - DJANGO='django>=1.4,<1.5'
     - DJANGO='django>=1.5,<1.6'
-    - DJANGO='django>=1.6<1.7'
+    - DJANGO='django>=1.6,<1.7'
     - DJANGO='https://www.djangoproject.com/download/1.7c1/tarball/'
 matrix:
     exclude:
+        -   python: 2.6
+            env: DJANGO='https://www.djangoproject.com/download/1.7c1/tarball/'
         -   python: 3.2
             env: DJANGO='django>=1.4,<1.5'
         -   python: 3.3


### PR DESCRIPTION
...n of Django for Python 2.6
