### PR TITLE
The embedded javascript catalog should be cached

### DIFF
--- a/djangojs/urls.py
+++ b/djangojs/urls.py
@@ -6,7 +6,7 @@ from os.path import join, isdir
 from django.conf.urls import patterns, url
 
 from djangojs.conf import settings
-from djangojs.views import UrlsJsonView, ContextJsonView, JsInitView
+from djangojs.views import UrlsJsonView, ContextJsonView, JsInitView, cached_javascript_catalog
 
 
 def js_info_dict():
@@ -33,5 +33,5 @@ urlpatterns = patterns('',
     url(r'^init\.js$', JsInitView.as_view(), name='django_js_init'),
     url(r'^urls$', UrlsJsonView.as_view(), name='django_js_urls'),
     url(r'^context$', ContextJsonView.as_view(), name='django_js_context'),
-    url(r'^translation$', 'django.views.i18n.javascript_catalog', js_info_dict(), name='js_catalog'),
+    url(r'^translation$', cached_javascript_catalog, js_info_dict(), name='js_catalog'),
 )

--- a/djangojs/views.py
+++ b/djangojs/views.py
@@ -12,6 +12,7 @@ from django.http import HttpResponse
 from django.utils.cache import patch_vary_headers
 from django.views.decorators.cache import cache_page
 from django.views.generic import View, TemplateView
+from django.views.i18n import javascript_catalog
 
 from djangojs.conf import settings
 from djangojs.urls_serializer import urls_as_dict, urls_as_json
@@ -150,3 +151,8 @@ class QUnitView(JsTestView):
         context = super(QUnitView, self).get_context_data(**kwargs)
         context['css_theme'] = 'js/test/libs/%s.css' % self.theme
         return context
+
+
+@cache_page(60 * settings.JS_CACHE_DURATION)
+def cached_javascript_catalog(request, domain='djangojs', packages=None):
+    return javascript_catalog(request, domain, packages)


### PR DESCRIPTION
Here is a proposal in order to allow the javascript catalog embedded in _django.js_ to use the `JS_CACHE_DURATION` setting.
