### PR TITLE
make django js compatible for django >=1.8

### DIFF
--- a/djangojs/templatetags/js.py
+++ b/djangojs/templatetags/js.py
@@ -4,6 +4,9 @@ Provide template tags to help with Javascript/Django integration.
 '''
 from __future__ import unicode_literals
 
+import django
+from distutils.version import StrictVersion
+
 from django import template
 from django.contrib.staticfiles.storage import staticfiles_storage
 from django.utils import six
@@ -12,6 +15,11 @@ from djangojs import JQUERY_MIGRATE_VERSION
 from djangojs.conf import settings
 
 register = template.Library()
+
+if StrictVersion(django.get_version()) >= StrictVersion("1.8"):
+    tokens = template.base
+else:
+    tokens = template
 
 
 def verbatim_tags(parser, token, endtagname):
@@ -39,14 +47,14 @@ def verbatim_tags(parser, token, endtagname):
         if token.contents == endtagname:
             break
 
-        if token.token_type == template.TOKEN_VAR:
+        if token.token_type == tokens.TOKEN_VAR:
             text_and_nodes.append('{{')
             text_and_nodes.append(token.contents)
 
-        elif token.token_type == template.TOKEN_TEXT:
+        elif token.token_type == tokens.TOKEN_TEXT:
             text_and_nodes.append(token.contents)
 
-        elif token.token_type == template.TOKEN_BLOCK:
+        elif token.token_type == tokens.TOKEN_BLOCK:
             try:
                 command = token.contents.split()[0]
             except IndexError:
@@ -63,7 +71,7 @@ def verbatim_tags(parser, token, endtagname):
                     raise
             text_and_nodes.append(node)
 
-        if token.token_type == template.TOKEN_VAR:
+        if token.token_type == tokens.TOKEN_VAR:
             text_and_nodes.append('}}')
 
     return text_and_nodes


### PR DESCRIPTION
django.js is not compatible with django 1.8 and up because `TOKEN_VAR` is no more in `django.template` but in `django.template.base`. This PR fix the problem and is still compatible with django < 1.8
