### PR TITLE
Fix name version

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,13 +1,13 @@
 Changelog
 =========
 
-Current
--------
-
-- Nothing yet
-
-0.8.1 (2013-10-19)
+0.8.1-django18-rc1
 ------------------
+
+- Make django.js compatible for django >= 1.8
+
+0.8.1-django18-rc1 (2015-12-14)
+-------------------------------
 
 - Fixed management command with Django < 1.5 (fix `issue #23 <https://github.com/noirbizarre/django.js/issues/23>`_ thanks to Wasil Sergejczyk)
 - Fixed Django CMS handling (fix `issue #25 <https://github.com/noirbizarre/django.js/issues/25>`_ thanks to Wasil Sergejczyk)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,13 +1,13 @@
 Changelog
 =========
 
-0.8.2-django18-rc2
-------------------
+0.8.3.novapost
+--------------
 
 - Make django.js compatible for django >= 1.8
 
-0.8.2-django18-rc2 (2015-12-16)
--------------------------------
+0.8.1 (2013-10-19)
+------------------
 
 - Fixed management command with Django < 1.5 (fix `issue #23 <https://github.com/noirbizarre/django.js/issues/23>`_ thanks to Wasil Sergejczyk)
 - Fixed Django CMS handling (fix `issue #25 <https://github.com/noirbizarre/django.js/issues/25>`_ thanks to Wasil Sergejczyk)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,8 +1,8 @@
 Changelog
 =========
 
-0.8.3.novapost
---------------
+0.8.2.novapost (2016-01-04)
+---------------------------
 
 - Make django.js compatible for django >= 1.8
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,12 +1,12 @@
 Changelog
 =========
 
-0.8.1-django18-rc1
+0.8.2-django18-rc2
 ------------------
 
 - Make django.js compatible for django >= 1.8
 
-0.8.1-django18-rc1 (2015-12-14)
+0.8.2-django18-rc2 (2015-12-16)
 -------------------------------
 
 - Fixed management command with Django < 1.5 (fix `issue #23 <https://github.com/noirbizarre/django.js/issues/23>`_ thanks to Wasil Sergejczyk)

--- a/djangojs/__init__.py
+++ b/djangojs/__init__.py
@@ -3,7 +3,7 @@
 Django.js provide better integration of javascript into Django.
 '''
 
-__version__ = '0.8.1-django18-rc1'
+__version__ = '0.8.2-django18-rc2'
 __description__ = "Django JS Tools"
 
 #: Packaged jQuery version

--- a/djangojs/__init__.py
+++ b/djangojs/__init__.py
@@ -3,7 +3,7 @@
 Django.js provide better integration of javascript into Django.
 '''
 
-__version__ = '0.8.2.novapost'
+__version__ = '0.8.2+novapost'
 __description__ = "Django JS Tools"
 
 #: Packaged jQuery version

--- a/djangojs/__init__.py
+++ b/djangojs/__init__.py
@@ -3,7 +3,7 @@
 Django.js provide better integration of javascript into Django.
 '''
 
-__version__ = '0.8.3.novapost'
+__version__ = '0.8.2.novapost'
 __description__ = "Django JS Tools"
 
 #: Packaged jQuery version

--- a/djangojs/__init__.py
+++ b/djangojs/__init__.py
@@ -3,7 +3,7 @@
 Django.js provide better integration of javascript into Django.
 '''
 
-__version__ = '0.8.2-django18-rc2'
+__version__ = '0.8.3.novapost'
 __description__ = "Django JS Tools"
 
 #: Packaged jQuery version

--- a/djangojs/__init__.py
+++ b/djangojs/__init__.py
@@ -3,7 +3,7 @@
 Django.js provide better integration of javascript into Django.
 '''
 
-__version__ = '0.8.2.dev'
+__version__ = '0.8.1-django18-rc1'
 __description__ = "Django JS Tools"
 
 #: Packaged jQuery version

--- a/djangojs/templatetags/js.py
+++ b/djangojs/templatetags/js.py
@@ -4,6 +4,9 @@ Provide template tags to help with Javascript/Django integration.
 '''
 from __future__ import unicode_literals
 
+import django
+from distutils.version import StrictVersion
+
 from django import template
 from django.contrib.staticfiles.storage import staticfiles_storage
 from django.utils import six
@@ -12,6 +15,11 @@ from djangojs import JQUERY_MIGRATE_VERSION
 from djangojs.conf import settings
 
 register = template.Library()
+
+if StrictVersion(django.get_version()) >= StrictVersion("1.8"):
+    tokens = template.base
+else:
+    tokens = template
 
 
 def verbatim_tags(parser, token, endtagname):
@@ -39,14 +47,14 @@ def verbatim_tags(parser, token, endtagname):
         if token.contents == endtagname:
             break
 
-        if token.token_type == template.TOKEN_VAR:
+        if token.token_type == tokens.TOKEN_VAR:
             text_and_nodes.append('{{')
             text_and_nodes.append(token.contents)
 
-        elif token.token_type == template.TOKEN_TEXT:
+        elif token.token_type == tokens.TOKEN_TEXT:
             text_and_nodes.append(token.contents)
 
-        elif token.token_type == template.TOKEN_BLOCK:
+        elif token.token_type == tokens.TOKEN_BLOCK:
             try:
                 command = token.contents.split()[0]
             except IndexError:
@@ -63,7 +71,7 @@ def verbatim_tags(parser, token, endtagname):
                     raise
             text_and_nodes.append(node)
 
-        if token.token_type == template.TOKEN_VAR:
+        if token.token_type == tokens.TOKEN_VAR:
             text_and_nodes.append('}}')
 
     return text_and_nodes

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ if sys.version_info[0:2] < (2, 7):
     install_requires += ['argparse']
 
 setup(
-    name='django.js',
+    name='novadjango.js',
     version=__import__('djangojs').__version__,
     description=__import__('djangojs').__description__,
     long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ if sys.version_info[0:2] < (2, 7):
     install_requires += ['argparse']
 
 setup(
-    name='django.js',
+    name='django-js',
     version=__import__('djangojs').__version__,
     description=__import__('djangojs').__description__,
     long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ if sys.version_info[0:2] < (2, 7):
     install_requires += ['argparse']
 
 setup(
-    name='novadjango.js',
+    name='django.js',
     version=__import__('djangojs').__version__,
     description=__import__('djangojs').__description__,
     long_description=long_description,


### PR DESCRIPTION
Fix name django.js to django-js for PEP 440
Fix version 0.8.2.novapost to 0.8.2+novapost for PEP 503
Plus making django 1.8 compatible
